### PR TITLE
Remove the extra space in the output message

### DIFF
--- a/R/utils_manager.R
+++ b/R/utils_manager.R
@@ -139,7 +139,7 @@ upload_document <- function(file, file_info,
   
   
   if(isTRUE(update)){
-    start_process("Updating document with local changes  to Google Drive...")
+    start_process("Updating document with local changes to Google Drive...")
     
     # Update document
     res <- googledrive::drive_update(


### PR DESCRIPTION
Sorry about this, but the extra space in the output message of this frequently used function could trigger OCD.