### PR TITLE
Fix default `gfile` name in `render_file`

### DIFF
--- a/R/files_manager.R
+++ b/R/files_manager.R
@@ -389,7 +389,7 @@ download_file <- function(file,
 #'
 
 render_file <- function(file,
-                        gfile = basename(file),
+                        gfile = NULL,
                         gpath = "trackdown",
                         shared_drive = NULL,
                         force = FALSE,

--- a/man/render_file.Rd
+++ b/man/render_file.Rd
@@ -6,7 +6,7 @@
 \usage{
 render_file(
   file,
-  gfile = basename(file),
+  gfile = NULL,
   gpath = "trackdown",
   shared_drive = NULL,
   force = FALSE,


### PR DESCRIPTION
The current implementation of `render_file` uses as a default `gfile=basename(file)` which returns the filename with the extensions, while the other functions (eg. `download_file`) use as default `gfile=NULL` which then gets expanded in the filename without the extensions. This is done in the [`get_file_info`](https://github.com/ClaudioZandonella/trackdown/blob/fee37ea899abc15eb0b5778e62b2e32ce3343fc2/R/utils.R#L157) function.

This is an issue as the default file names are not the same and `render_file` doesn't work in `gfile` is not manually specified.

This commit fix the issue in `render_file` by having the same behavior of the other functions.