### PR TITLE
add quick way to use own app

### DIFF
--- a/R/trackdown_auth.R
+++ b/R/trackdown_auth.R
@@ -44,6 +44,12 @@ check_from_trackdown <- function (env = parent.frame()){
 #' 
 
 trackdown_app <- function(){
+  # priority to user provided app
+  user_app <- getOption("trackdown-app")
+  if (!is.null(user_app)) {
+    return(user_app)
+  }
+  
   check_from_trackdown(parent.frame())
   .trackdown_auth()
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.re
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5167319.svg)](https://doi.org/10.5281/zenodo.5167319)
 <!-- badges: end -->
 
+> **IMPORTANT**
+>
+> We currently reached the maximum number of users for the API credentails. Installing the development `trackdown` from GitHub will require to create your own API credentials. Please, see https://github.com/ClaudioZandonella/trackdown/issues/37#issuecomment-1330785927. More detailed information will be provided.
+>
+> Sorry for the issue. We hope too solve this problem as soon as possible.
+
 ## Overview
 
 The `trackdown` package offers a simple solution for collaborative


### PR DESCRIPTION
Fix #37 

As far as I understand, currently trackdown uses credentials that are saved in sysdata.rda.

Still WIP, untested beyond checking what `active_trackdown_app()` returns, as I haven't created an app in Google Cloud dashboard yet. It's also not necessarily the best way to use one's own app: it'd be nice to have a function as in gmailr https://gmailr.r-lib.org/articles/gmailr.html#external-setup `gmailr::gm_auth_configure()`.

With this fork one would run

```r
my_app_name <- "trackdown-rpackage-fork"
my_app_secret <- "GOCSblablabla"
my_app_key <- "blablablabla.apps.googleusercontent.com"

my_app <- httr::oauth_app(
  appname = my_app_name,
  secret = my_app_secret,
  key = my_app_key
)

options("trackdown-app" = my_app)
```

Cc @krlmlr