### PR TITLE
Use Bootstrap 5 for pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,5 @@
 # template:
 #   params:
 #     ganalytics: G-38DDQEVS94
+template:
+  bootstrap: 5


### PR DESCRIPTION
I am suggesting this in particular because it makes the font size bigger. :mag: :grin: For context see https://pkgdown.r-lib.org/articles/customise.html#getting-started