### PR TITLE
suggestion for the reference index

### DIFF
--- a/R/trackdown-package.R
+++ b/R/trackdown-package.R
@@ -112,6 +112,7 @@
 #' @import rlang
 #'
 #' @docType package
+#' @keywords internal
 #' @name trackdown-package
 NULL
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,19 @@
 # template:
 #   params:
 #     ganalytics: G-38DDQEVS94
+
+reference:
+- title: Authentication
+  contents:
+  - trackdown_auth
+  - trackdown_auth_configure
+  - trackdown_has_token
+  - trackdown_token
+  - trackdown_user
+  - trackdown_deauth
+- title: Document management
+  contents:
+  - download_file
+  - render_file
+  - update_file
+  - upload_file

--- a/man/trackdown-package.Rd
+++ b/man/trackdown-package.Rd
@@ -117,3 +117,4 @@ possible to:
  }
 }
 
+\keyword{internal}


### PR DESCRIPTION
- make the package manual page "internal" so that it does not show up in the reference index (nor the local one nor the pkgdown one)
- add grouping to the configuration for the pkgdown reference index