### PR TITLE
docs: activate Markdown syntax for roxygen2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,3 +51,4 @@ RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 URL: https://github.com/claudiozandonella/trackdown/, https://claudiozandonella.github.io/trackdown/
 BugReports: https://github.com/claudiozandonella/trackdown/issues
+Roxygen: list(markdown = TRUE)

--- a/R/files_manager.R
+++ b/R/files_manager.R
@@ -42,8 +42,6 @@
 #'   settings for rich_text. See “Rich Text” in details section.
 #' @param force logical value indicating whether to skip confirm check by user
 #'   (default is `FALSE`).
-#' @param open logical value indicating whether to open the created file in 
-#' a browser (default is `TRUE` in interactive sessions).
 #'
 #' @return a dribble of the uploaded file (and output if specified).
 #'
@@ -84,8 +82,7 @@ upload_file <- function(file,
                         path_output = NULL,
                         rich_text = TRUE,
                         rich_text_par = NULL,
-                        force = FALSE,
-                        open = rlang::is_interactive()) {
+                        force = FALSE) {
   
   main_process(paste("Uploading files to", cli::col_magenta("Google Drive")))
   

--- a/R/files_manager.R
+++ b/R/files_manager.R
@@ -34,11 +34,11 @@
 #'   upload together with the other file. PDF are directly uploaded, HTML can be
 #'   first converted into PDF if package `pagedown` and Chrome are
 #'   available.
-#' @param rich_text [experimental] logical value (default is `TRUE`)
+#' @param rich_text (experimental) logical value (default is `TRUE`)
 #'   indicating whether to upload to Google Docs a rich document (i.e.,
 #'   important text that should not be changed is highlighted). See “Rich Text”
 #'   in details section.
-#' @param rich_text_par [experimental] argument used to pass a list with custom
+#' @param rich_text_par (experimental) argument used to pass a list with custom
 #'   settings for rich_text. See “Rich Text” in details section.
 #' @param force logical value indicating whether to skip confirm check by user
 #'   (default is `FALSE`).
@@ -47,7 +47,7 @@
 #'
 #' @details
 #'
-#' **Rich Text [experimental]**
+#' **Rich Text (experimental)**
 #'
 #' The `rich_text` option (default is `TRUE`) allows to upload a rich
 #' document to Google Docs. Important text that should not be changed is
@@ -277,7 +277,7 @@ update_file <- function(file,
 #' [trackdown-package()] help page.
 #'
 #' @inheritParams upload_file
-#' @param rm_gcomments [experimental] logical value indicating whether or not to
+#' @param rm_gcomments (experimental) logical value indicating whether or not to
 #'   remove Google comments.
 #'
 #' @return `TRUE` if file from Google Drive was saved, `FALSE` otherwise.

--- a/R/files_manager.R
+++ b/R/files_manager.R
@@ -10,12 +10,12 @@
 #' upload the file if it doesn't already exist in the chosen location. By
 #' default files are uploaded in the folder "trackdown", if is not available on
 #' Google Drive, permission to create it is required to the user. To update an
-#' already existing file see \code{\link{update_file}}. It is also possible to
-#' upload the output (pdf or html) of the file specifying the \code{path_output}
-#' argument. In case of html files, if \code{pagedown} package and Chrome are
+#' already existing file see [update_file()]. It is also possible to
+#' upload the output (pdf or html) of the file specifying the `path_output`
+#' argument. In case of html files, if `pagedown` package and Chrome are
 #' available, users can decide to upload a pdf version of the html file.\cr\cr
-#' To know more about \code{trackdown} workflow and features see
-#' \code{\link{trackdown-package}} help page.
+#' To know more about `trackdown` workflow and features see
+#' [trackdown-package()] help page.
 #'
 #' @param file character. The path of a local `.Rmd`, Quarto, or `.Rnw` file.
 #' @param gfile character. The name of a Google Drive file (defaults to local
@@ -23,41 +23,43 @@
 #' @param gpath character. (Sub)directory in My Drive or a shared drive
 #'   (optional). By default files are uploaded in the folder "trackdown". To
 #'   specify another folder the full path is required (e.g.,
-#'   "trackdown/my_folder"). Use \code{NULL} to upload directly at the root
+#'   "trackdown/my_folder"). Use `NULL` to upload directly at the root
 #'   level, although it is not recommended.
 #' @param shared_drive character. The name of a Google Drive shared drive
 #'   (optional).
 #' @param hide_code logical value indicating whether to remove code from the
 #'   text document (chunks and header). Placeholders of type "[[chunk-<name>]]"
 #'   are displayed instead.
-#' @param  path_output default \code{NULL}, specify the path to the output to
+#' @param  path_output default `NULL`, specify the path to the output to
 #'   upload together with the other file. PDF are directly uploaded, HTML can be
-#'   first converted into PDF if package \code{pagedown} and Chrome are
+#'   first converted into PDF if package `pagedown` and Chrome are
 #'   available.
-#' @param rich_text [experimental] logical value (default is \code{TRUE})
+#' @param rich_text [experimental] logical value (default is `TRUE`)
 #'   indicating whether to upload to Google Docs a rich document (i.e.,
 #'   important text that should not be changed is highlighted). See “Rich Text”
 #'   in details section.
 #' @param rich_text_par [experimental] argument used to pass a list with custom
 #'   settings for rich_text. See “Rich Text” in details section.
 #' @param force logical value indicating whether to skip confirm check by user
-#'   (default is \code{FALSE}).
+#'   (default is `FALSE`).
+#' @param open logical value indicating whether to open the created file in 
+#' a browser (default is `TRUE` in interactive sessions).
 #'
 #' @return a dribble of the uploaded file (and output if specified).
 #'
 #' @details
 #'
-#' \strong{Rich Text [experimental]}
+#' **Rich Text [experimental]**
 #'
-#' The \code{rich_text} option (default is \code{TRUE}) allows to upload a rich
+#' The `rich_text` option (default is `TRUE`) allows to upload a rich
 #' document to Google Docs. Important text that should not be changed is
 #' highlighted. This includes, added instructions at the top of the document,
 #' placeholders hiding the code, header of the document (YAML header or LaTeX
 #' preamble), code chunks, and in-line code.
 #'
 #' Default colour is opaque yellow. You can customize the colour specifying the
-#' \code{rgb_color} option in the \code{rich_text_par} argument. The
-#' \code{rgb_color} has to be a list with elements \code{red}, \code{green}, and \code{blue}.
+#' `rgb_color` option in the `rich_text_par` argument. The
+#' `rgb_color` has to be a list with elements `red`, `green`, and `blue`.
 #' Each element has to be a numeric value between 0 and 1. See example below.
 #'
 #' @export
@@ -82,7 +84,8 @@ upload_file <- function(file,
                         path_output = NULL,
                         rich_text = TRUE,
                         rich_text_par = NULL,
-                        force = FALSE) {
+                        force = FALSE,
+                        open = rlang::is_interactive()) {
   
   main_process(paste("Uploading files to", cli::col_magenta("Google Drive")))
   
@@ -150,13 +153,13 @@ upload_file <- function(file,
 #' Replaces the content of an existing file in Google Drive with the contents of
 #' a local file. It is also possible to update (or upload if not already
 #' present) the output (pdf or html) of the file specifying the
-#' \code{path_output} argument. In case of html files, if \code{pagedown}
+#' `path_output` argument. In case of html files, if `pagedown`
 #' package and Chrome are available, users can decide to upload a pdf version of
 #' the html file.\cr\cr
-#' \emph{Use with caution as tracked changes in the Google Drive file will be
-#' lost!}\cr\cr 
-#' To know more about \code{trackdown} workflow and features see
-#' \code{\link{trackdown-package}} help page.
+#' *Use with caution as tracked changes in the Google Drive file will be
+#' lost!*\cr\cr 
+#' To know more about `trackdown` workflow and features see
+#' [trackdown-package()] help page.
 #'
 #' @inheritParams upload_file
 #' 
@@ -271,10 +274,10 @@ update_file <- function(file,
 #'
 #' Download edited version of a file from Google Drive updating the local
 #' version with the new changes.\cr\cr
-#' \emph{Use with caution as local version of the file will be
-#' overwritten!}\cr\cr 
-#' To know more about \code{trackdown} workflow and features see
-#' \code{\link{trackdown-package}} help page.
+#' *Use with caution as local version of the file will be
+#' overwritten!*\cr\cr 
+#' To know more about `trackdown` workflow and features see
+#' [trackdown-package()] help page.
 #'
 #' @inheritParams upload_file
 #' @param rm_gcomments [experimental] logical value indicating whether or not to
@@ -377,8 +380,8 @@ download_file <- function(file,
 #' Render file from Google Drive
 #'
 #' Render file from Google Drive if there have been edits\cr\cr
-#' To know more about \code{trackdown} workflow and features see
-#' \code{\link{trackdown-package}} help page.
+#' To know more about `trackdown` workflow and features see
+#' [trackdown-package()] help page.
 #' 
 #' @inheritParams upload_file
 #' @param rm_gcomments [experimental] logical value indicating whether or not to

--- a/R/files_manager.R
+++ b/R/files_manager.R
@@ -28,7 +28,7 @@
 #' @param shared_drive character. The name of a Google Drive shared drive
 #'   (optional).
 #' @param hide_code logical value indicating whether to remove code from the
-#'   text document (chunks and header). Placeholders of type "[[chunk-<name>]]"
+#'   text document (chunks and header). Placeholders of type `"[[chunk-<name>]]"`
 #'   are displayed instead.
 #' @param  path_output default `NULL`, specify the path to the output to
 #'   upload together with the other file. PDF are directly uploaded, HTML can be

--- a/R/files_manager.R
+++ b/R/files_manager.R
@@ -381,7 +381,7 @@ download_file <- function(file,
 #' [trackdown-package()] help page.
 #' 
 #' @inheritParams upload_file
-#' @param rm_gcomments [experimental] logical value indicating whether or not to
+#' @param rm_gcomments (experimental) logical value indicating whether or not to
 #'   remove Google comments.
 #' @return `TRUE` if file from Google Drive was saved and rendered, `FALSE`
 #'   otherwise.

--- a/R/rich_text.R
+++ b/R/rich_text.R
@@ -149,12 +149,11 @@ get_param_request <-  function(text,
 #' @param token Token used for API authentication
 #' @param base_url string indicating the API base URL
 #'
-#' @return named list with \itemize{
-#'   \item{method} string indicating the hTTP method (GET or POST) 
-#'   \item{url} string indicating the full URL used for the query
-#'   \item{body} named list with the body of the query
-#'   \item{token} Token used for API authentication
-#' }
+#' @return named list with
+#'   - **method** string indicating the hTTP method (GET or POST) 
+#'   - **url** string indicating the full URL used for the query
+#'   - **body** named list with the body of the query
+#'   - **token** Token used for API authentication
 #' 
 #' @noRd
 #' @examples

--- a/R/trackdown-package.R
+++ b/R/trackdown-package.R
@@ -6,31 +6,31 @@
 
 #' trackdown - R package for improving collaborative writing
 #'
-#' The \code{trackdown} package offers a simple solution for collaborative
+#' The `trackdown` package offers a simple solution for collaborative
 #' writing and editing of R Markdown (or Sweave) documents. Using
-#' \code{trackdown}, the local \code{.Rmd} (or \code{.Rnw}) file can be uploaded
+#' `trackdown`, the local `.Rmd` (or `.Rnw`) file can be uploaded
 #' as a plain-text file to Google Drive. By taking advantage of the easily
 #' readable Markdown (or LaTeX) syntax and the well-known online interface
 #' offered by Google Docs, collaborators can easily contribute to the writing
 #' and editing process. After integrating all authors’ contributions, the final
 #' document can be downloaded and rendered locally.
 #'
-#' @section The \code{trackdown} Workflow:
-#'  During the collaborative writing/editing of an \code{.Rmd} (or \code{.Rnw})
+#' @section The `trackdown` Workflow:
+#'  During the collaborative writing/editing of an `.Rmd` (or `.Rnw`)
 #'  document, it is important to employ different workflows for computer code
 #'  and narrative text:
 #'
 #'  \itemize{ 
-#'   \item{\strong{Code} - Collaborative code writing is done most efficiently
-#'   by following a traditional \strong{Git}-based workflow using an online
+#'   \item{**Code** - Collaborative code writing is done most efficiently
+#'   by following a traditional **Git**-based workflow using an online
 #'   repository (e.g., GitHub or GitLab).}
-#'   \item{\strong{Narrative Text} - Collaborative writing of narrative text is
-#'   done most efficiently using \strong{Google Docs} which provides a familiar
+#'   \item{**Narrative Text** - Collaborative writing of narrative text is
+#'   done most efficiently using **Google Docs** which provides a familiar
 #'   and simple online interface that allows multiple users to simultaneously
 #'   write/edit the same document.}
 #'   }
 #'
-#'  Thus, the workflow’s main idea is simple: Upload the \code{.Rmd} (or \code{.Rnw})
+#'  Thus, the workflow’s main idea is simple: Upload the `.Rmd` (or `.Rnw`)
 #'  document to Google Drive to collaboratively write/edit the narrative text in
 #'  Google Docs; download the document locally to continue working on the code
 #'  while harnessing the power of Git for version control and collaboration.
@@ -38,39 +38,39 @@
 #'  continues until the desired results are obtained. The workflow can be
 #'  summarized as:
 #'
-#'  \emph{Collaborative \strong{code} writing using \strong{Git} & collaborative writing
-#'  of \strong{narrative text} using \strong{Google Docs} }
+#'  \emph{Collaborative **code** writing using **Git** & collaborative writing
+#'  of **narrative text** using **Google Docs** }
 #'   
 #' @section Functions:
-#'  \code{trackdown} offers different functions to manage the workflow:
+#'  `trackdown` offers different functions to manage the workflow:
 #'  \itemize{
-#'   \item{\code{\link{upload_file}} uploads a file for the first time to Google
+#'   \item{[upload_file()] uploads a file for the first time to Google
 #'   Drive.}
-#'   \item{\code{\link{update_file}} updates the content of an existing file in
+#'   \item{[update_file()] updates the content of an existing file in
 #'   Google Drive with the contents of a local file.}
-#'   \item{\code{\link{download_file}} downloads the edited version of a file
+#'   \item{[download_file()] downloads the edited version of a file
 #'   from Google Drive and updates the local version.}
-#'   \item{\code{\link{render_file}} downloads a file from Google Drive and
+#'   \item{[render_file()] downloads a file from Google Drive and
 #'   renders it locally.}
 #'  }
 #'  
 #' @section Special Features:
-#' \code{trackdown} offers additional features to facilitate the collaborative
+#' `trackdown` offers additional features to facilitate the collaborative
 #' writing and editing of documents in Google Docs. In particular, it is
 #' possible to:
 #' \itemize{
-#'   \item{\strong{Hide Code:} Code in the header of the document (YAML header
+#'   \item{**Hide Code:** Code in the header of the document (YAML header
 #'   or LaTeX preamble) and code chunks are removed from the document when
 #'   uploading to Google Drive and are automatically restored during download.
 #'   This prevents collaborators from inadvertently making changes to the code
 #'   which might corrupt the file and allows them to focus on the narrative
 #'   text.}
-#'   \item{\strong{Upload Output:} The actual output document (i.e., the
+#'   \item{**Upload Output:** The actual output document (i.e., the
 #'   rendered file) can be uploaded to Google Drive in conjunction with the
-#'   \code{.Rmd} (or \code{.Rnw}) document. This helps collaborators to evaluate
+#'   `.Rmd` (or `.Rnw`) document. This helps collaborators to evaluate
 #'   the overall layout including figures and tables and allows them to add
 #'   comments to suggest and discuss changes.}
-#'   \item{\strong{Use Google Drive shared drives:} The documents can be
+#'   \item{**Use Google Drive shared drives:** The documents can be
 #'   uploaded on your personal Google Drive or on a shared drive to facilitate
 #'   collaboration.}
 #'  }
@@ -91,20 +91,20 @@
 #'  
 #'  Note that not all collaborators have to have a Google account (although this
 #'  is recommended to utilize all Google Docs features). Only the person who
-#'  manages the \code{trackdown} workflow needs to have a Google account to
+#'  manages the `trackdown` workflow needs to have a Google account to
 #'  upload files to Google Drive. Other collaborators can be invited to
 #'  contribute to the document using a shared link.
 #'  
 #' @section Documentation and Vignettes:
-#'  All the documentation is available at \url{https://claudiozandonella.github.io/trackdown/}.
+#'  All the documentation is available at <https://claudiozandonella.github.io/trackdown/>.
 #'  
-#'  To know more about the \code{trackdown}, please reference:
+#'  To know more about the `trackdown`, please reference:
 #'  \itemize{
-#'   \item{\code{vignette("trackdown-features")} for a detailed description of
+#'   \item{`vignette("trackdown-features")` for a detailed description of
 #'   the function arguments and features.}
-#'   \item{\code{vignette("trackdown-workflow")} for a workflow example and
+#'   \item{`vignette("trackdown-workflow")` for a workflow example and
 #'   discussion of how to collaborate on narrative text and code.}
-#'   \item{\code{vignette("trackdown-tech-notes")} for details regarding
+#'   \item{`vignette("trackdown-tech-notes")` for details regarding
 #'   technical details like authentication and file management.}
 #'  }
 #'

--- a/R/trackdown-package.R
+++ b/R/trackdown-package.R
@@ -20,15 +20,13 @@
 #'  document, it is important to employ different workflows for computer code
 #'  and narrative text:
 #'
-#'  \itemize{ 
-#'   \item{**Code** - Collaborative code writing is done most efficiently
+#'   - **Code** - Collaborative code writing is done most efficiently
 #'   by following a traditional **Git**-based workflow using an online
-#'   repository (e.g., GitHub or GitLab).}
-#'   \item{**Narrative Text** - Collaborative writing of narrative text is
+#'   repository (e.g., GitHub or GitLab).
+#'   - **Narrative Text** - Collaborative writing of narrative text is
 #'   done most efficiently using **Google Docs** which provides a familiar
 #'   and simple online interface that allows multiple users to simultaneously
-#'   write/edit the same document.}
-#'   }
+#'   write/edit the same document.
 #'
 #'  Thus, the workflow’s main idea is simple: Upload the `.Rmd` (or `.Rnw`)
 #'  document to Google Drive to collaboratively write/edit the narrative text in
@@ -42,49 +40,44 @@
 #'  of **narrative text** using **Google Docs** }
 #'   
 #' @section Functions:
-#'  `trackdown` offers different functions to manage the workflow:
-#'  \itemize{
-#'   \item{[upload_file()] uploads a file for the first time to Google
-#'   Drive.}
-#'   \item{[update_file()] updates the content of an existing file in
-#'   Google Drive with the contents of a local file.}
-#'   \item{[download_file()] downloads the edited version of a file
-#'   from Google Drive and updates the local version.}
-#'   \item{[render_file()] downloads a file from Google Drive and
-#'   renders it locally.}
-#'  }
+#' `trackdown` offers different functions to manage the workflow:
+#'   * [upload_file()] uploads a file for the first time to Google
+#'   Drive.
+#'   * [update_file()] updates the content of an existing file in
+#'   Google Drive with the contents of a local file.
+#'   * downloads the edited version of a file
+#'   from Google Drive and updates the local version.
+#'   * [render_file()] downloads a file from Google Drive and
+#'   renders it locally.
 #'  
 #' @section Special Features:
 #' `trackdown` offers additional features to facilitate the collaborative
 #' writing and editing of documents in Google Docs. In particular, it is
 #' possible to:
-#' \itemize{
-#'   \item{**Hide Code:** Code in the header of the document (YAML header
+#' - **Hide Code:** Code in the header of the document (YAML header
 #'   or LaTeX preamble) and code chunks are removed from the document when
 #'   uploading to Google Drive and are automatically restored during download.
 #'   This prevents collaborators from inadvertently making changes to the code
 #'   which might corrupt the file and allows them to focus on the narrative
-#'   text.}
-#'   \item{**Upload Output:** The actual output document (i.e., the
+#'   text.
+#' - **Upload Output:** The actual output document (i.e., the
 #'   rendered file) can be uploaded to Google Drive in conjunction with the
 #'   `.Rmd` (or `.Rnw`) document. This helps collaborators to evaluate
 #'   the overall layout including figures and tables and allows them to add
-#'   comments to suggest and discuss changes.}
-#'   \item{**Use Google Drive shared drives:** The documents can be
+#'   comments to suggest and discuss changes.
+#' - **Use Google Drive shared drives:** The documents can be
 #'   uploaded on your personal Google Drive or on a shared drive to facilitate
-#'   collaboration.}
-#'  }
+#'   collaboration.
 #'  
 #' @section Advantages of Google Docs:
 #'  Google Docs offers users a familiar, intuitive, and free web-based interface
 #'  that allows multiple users to simultaneously write/edit the same document.
 #'  In Google Docs it is possible to:
-#'  \itemize{
-#'   \item{track changes (incl. accepting/rejecting suggestions)}
-#'   \item{add comments to suggest and discuss changes}
-#'   \item{check spelling and grammar errors (potentially integrating
-#'   third-party services like Grammarly)}
-#'  }
+#'  - track changes (incl. accepting/rejecting suggestions)
+#'  - add comments to suggest and discuss changes
+#'  - check spelling and grammar errors (potentially integrating
+#'   third-party services like Grammarly)
+#'   
 #'  Moreover, Google Docs allows anyone to contribute to the writing/editing of
 #'  the document. No programming experience is required, users can just focus on
 #'  writing/editing the narrative text.
@@ -99,14 +92,12 @@
 #'  All the documentation is available at <https://claudiozandonella.github.io/trackdown/>.
 #'  
 #'  To know more about the `trackdown`, please reference:
-#'  \itemize{
-#'   \item{`vignette("trackdown-features")` for a detailed description of
-#'   the function arguments and features.}
-#'   \item{`vignette("trackdown-workflow")` for a workflow example and
-#'   discussion of how to collaborate on narrative text and code.}
-#'   \item{`vignette("trackdown-tech-notes")` for details regarding
-#'   technical details like authentication and file management.}
-#'  }
+#'  - `vignette("trackdown-features")` for a detailed description of
+#'   the function arguments and features.
+#'  - `vignette("trackdown-workflow")` for a workflow example and
+#'   discussion of how to collaborate on narrative text and code.
+#'  - `vignette("trackdown-tech-notes")` for details regarding
+#'   technical details like authentication and file management.
 #'
 #' @importFrom utils tail head
 #' @import rlang

--- a/R/trackdown-package.R
+++ b/R/trackdown-package.R
@@ -36,8 +36,8 @@
 #'  continues until the desired results are obtained. The workflow can be
 #'  summarized as:
 #'
-#'  \emph{Collaborative **code** writing using **Git** & collaborative writing
-#'  of **narrative text** using **Google Docs** }
+#'  _Collaborative **code** writing using **Git** & collaborative writing
+#'  of **narrative text** using **Google Docs**_
 #'   
 #' @section Functions:
 #' `trackdown` offers different functions to manage the workflow:

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,7 +123,7 @@ finish_process <- function(message){
 #'
 #' @return a list with
 #' \itemize{
-#'   \item{path: the path to the file. If there is no path \code{"."} is
+#'   \item{path: the path to the file. If there is no path `"."` is
 #'   returned}
 #'   \item{file_name: file name with extension}
 #'   \item{extension: the file extension without point and all lowercase}

--- a/R/utils.R
+++ b/R/utils.R
@@ -122,13 +122,11 @@ finish_process <- function(message){
 #' @param file a string indicating the path to a file
 #'
 #' @return a list with
-#' \itemize{
-#'   \item{path: the path to the file. If there is no path `"."` is
-#'   returned}
-#'   \item{file_name: file name with extension}
-#'   \item{extension: the file extension without point and all lowercase}
-#'   \item{file_basename: the file name without extesion}
-#' }
+#' - path: the path to the file. If there is no path `"."` is
+#'   returned
+#' - file_name: file name with extension
+#' - extension: the file extension without point and all lowercase
+#'  - file_basename: the file name without extension
 #' 
 #' @noRd
 #' 
@@ -303,12 +301,10 @@ check_dribble <- function(dribble, gfile, test = c("none", "single", "both")){
 #' @param document character vector with the lines of the document 
 #'
 #' @return a list with:
-#' \itemize{
-#'   \item{instruction_start - integer inidicating the instructions initial line}
-#'   \item{instruction_end - integer inidicating the instructions end line}
-#'   \item{file_name - character indicating the file name}
-#'   \item{hide_code - logical indicating whether code was removed}
-#' }
+#' - instruction_start - integer inidicating the instructions initial line
+#' - instruction_end - integer inidicating the instructions end line
+#' - file_name - character indicating the file name
+#' - hide_code - logical indicating whether code was removed
 #' 
 #' @noRd 
 #'

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -38,10 +38,9 @@ mkdir_trackdown <- function(local_path, folder_name = ".trackdown"){
 #' @param info_patterns a list with the regex pattern according to file
 #'   extension, returned by get_extension_patterns() function
 #'
-#' @return  a tibble with \itemize{
-#'   \item{starts} the line number of the chunk header
-#'   \item{ends} the line number of the chunk end
-#' }
+#' @return  a tibble with
+#'   - **starts** the line number of the chunk header
+#'   - **ends** the line number of the chunk end
 #' @noRd
 #'
 #' @examples
@@ -95,16 +94,16 @@ get_chunk_range <- function(lines, info_patterns){
 #'   extension, returned by get_extension_patterns() function
 #' 
 #' @noRd
-#' @return  a tibble with \itemize{
-#'   \item{language} of the chunk
-#'   \item{name} of the chunk
-#'   \item{options} of the chunk
-#'   \item{starts} the line number of the chunk header
-#'   \item{ends} the line number of the chunk end
-#'   \item{index} integer index to identify the chunk
-#'   \item{chunk_text} the chunk from header to end (included)
-#'   \item{name_tag} the name used as tag in the text
-#' }
+#' @return  a tibble with 
+#'   - **language** of the chunk
+#'   - **name** of the chunk
+#'   - **options** of the chunk
+#'   - **starts** the line number of the chunk header
+#'   - **ends** the line number of the chunk end
+#'   - **index** integer index to identify the chunk
+#'   - **chunk_text** the chunk from header to end (included)
+#'   - **name_tag** the name used as tag in the text
+#'   
 #' Note that in case of "rnw" extension the language is always NA. NULL is
 #' returned if no chunk is available.
 #' 
@@ -160,12 +159,11 @@ extract_chunk <- function(text_lines, info_patterns){
 #'   extension, returned by get_extension_patterns() function
 #' 
 #' @noRd
-#' @return  a tibble with \itemize{
-#'   \item{starts} the line number of the header start
-#'   \item{ends} the line number of the header end
-#'   \item{header_text} the header form start to end (included)
-#'   \item{name_tag} the name used as tag in the text
-#' }
+#' @return  a tibble with
+#'   - **starts** the line number of the header start
+#'   - **ends** the line number of the header end
+#'   - **header_text** the header form start to end (included)
+#'   - **name_tag** the name used as tag in the text
 #' 
 #' @examples 
 #'   # rmd
@@ -223,12 +221,12 @@ check_header <- function(text_lines, info_patterns){
 #'   extension, returned by get_extension_patterns() function
 #' 
 #' @noRd
-#' @return  a tibble with \itemize{
-#'   \item{starts} the line number of the header start
-#'   \item{ends} the line number of the header end
-#'   \item{header_text} the header form start to end (included)
-#'   \item{name_tag} the name used as tag in the text
-#'   }
+#' @return  a tibble with
+#'   - **starts** the line number of the header start
+#'   - **ends** the line number of the header end
+#'   - **header_text** the header form start to end (included)
+#'   - **name_tag** the name used as tag in the text
+#'   
 #'   Note that if no header is available, NULL is returned
 #' 
 #' @examples 
@@ -289,15 +287,15 @@ extract_header <- function(text_lines, info_patterns){
 #' 
 #' @param extension string indicating the file extension ("rmd", "qmd", or "rnw")
 #'
-#' @return a list with the regex pattern that identify \itemize{
-#' \item{chunk_header_start} the start of the first line of a chunk
-#' \item{chunk_header_end} the end of the first line of a chunk
-#' \item{chunk_start} the start line of a chunk
-#' \item{chunk_end} the end line of a chunk
-#' \item{file_header_start} the start line of the file header
-#' \item{file_header_end} the end line of the file header
-#' \item{extension} the extension type (rmd, qmd or rnw)
-#' }
+#' @return a list with the regex pattern that identify
+#' - **chunk_header_start** the start of the first line of a chunk
+#' - **chunk_header_end** the end of the first line of a chunk
+#' - **chunk_start** the start line of a chunk
+#' - **chunk_end** the end line of a chunk
+#' - **file_header_start** the start line of the file header
+#' - **file_header_end** the end line of the file header
+#' - **extension** the extension type (rmd, qmd or rnw)
+#' 
 #' @noRd
 #'
 #' @examples
@@ -337,7 +335,7 @@ get_extension_patterns <- function(extension =  c("rmd", "qmd", "rnw")){
 #' Remove Code
 #'
 #' Remove code from the document (chunks and header). Placeholders of  type
-#' "[[chunk-<name>]]"/"[[Document-header]]" are displayed instead.
+#' `"[[chunk-<name>]]"`/`"[[Document-header]]"` are displayed instead.
 #'
 #' @param document character vector with the lines of the document 
 #' @param file_info list with file info returned from get_file_info() function
@@ -401,7 +399,7 @@ hide_code <- function(document, file_info){
 
 #' Restore the Downloaded File with Code Info
 #'
-#' Restore placeholders of type "[[chunk-<name>]]"/"[[Document-header]]" with
+#' Restore placeholders of type `"[[chunk-<name>]]"`/`"[[Document-header]]"` with
 #' the actual code and sanitize file.
 #'
 #' @param temp_file character indicating the path to the downloaded file

--- a/R/utils_chunk.R
+++ b/R/utils_chunk.R
@@ -405,7 +405,7 @@ hide_code <- function(document, file_info){
 #' @param temp_file character indicating the path to the downloaded file
 #' @param file_name character indicating the current file name
 #' @param path character indicating the folder of the original file
-#' @param rm_gcomments [experimental] logical value indicating whether or not to
+#' @param rm_gcomments (experimental) logical value indicating whether or not to
 #'   remove Google comments
 #'
 #' @return a single string with the content of the document

--- a/R/utils_dribble.R
+++ b/R/utils_dribble.R
@@ -16,10 +16,8 @@
 #'   (optional).
 #'
 #' @return A list with two dribble object:
-#' \itemize{
-#'  \item{file} dribble object about the gfile
-#'  \item{parent} dribble object about the parent item
-#' }
+#'  - **file** dribble object about the gfile
+#'  - **parent** dribble object about the parent item
 #' 
 #' @noRd
 #' @seealso [googledrive::dribble()]

--- a/R/utils_manager.R
+++ b/R/utils_manager.R
@@ -86,10 +86,10 @@ evaluate_file <- function(file,
 #'   are displayed instead.
 #' @param update logical value indicating whether to update or upload the
 #'   document.
-#' @param rich_text [experimental] logical value (default is `TRUE`)
+#' @param rich_text (experimental) logical value (default is `TRUE`)
 #'   indicating whether to upload to Google Docs a rich document (i.e.,
 #'   important text that should not be changed is highlighted).
-#' @param rich_text_par [experimental] argument used to pass a list with custom
+#' @param rich_text_par (experimental) argument used to pass a list with custom
 #'   settings for rich_text.
 #'
 #' @return a dribble of the uploaded (or updated) document

--- a/R/utils_manager.R
+++ b/R/utils_manager.R
@@ -15,14 +15,12 @@
 #'   single line in dribble ("single") or both condition accepted ("both")
 #'
 #' @return a list with relevant information 
-#'  \itemize{
-#'    \item{file - character indicating the path to the local file (or output)}
-#'    \item{file_info - list with file info returned from  get_file_info()
-#'    function}
-#'    \item{gfile - character indicating the corrected gfile naem for the file}
-#'    \item{dribble_info - list with dribble info of the file and parent
-#'    returned by get_dribble_info() function}
-#'  }
+#'  - file - character indicating the path to the local file (or output)
+#'  - file_info - list with file info returned from  get_file_info()
+#'    function
+#'  - gfile - character indicating the corrected gfile naem for the file
+#'  - dribble_info - list with dribble info of the file and parent
+#'    returned by get_dribble_info() function
 #'  
 #' @noRd
 #'
@@ -84,7 +82,7 @@ evaluate_file <- function(file,
 #' @param dribble_document A list with two dribble object regarding the gfile
 #'   and the parent item.
 #' @param hide_code logical value indicating whether to remove code from the
-#'   text document (chunks and header). Placeholders of  type "[[chunk-<name>]]"
+#'   text document (chunks and header). Placeholders of  type `"[[chunk-<name>]]"`
 #'   are displayed instead.
 #' @param update logical value indicating whether to update or upload the
 #'   document.

--- a/R/utils_manager.R
+++ b/R/utils_manager.R
@@ -71,8 +71,8 @@ evaluate_file <- function(file,
 #'
 #' Internal function to upload (or update) a local file to Google Drive as a
 #' plain text document. Local file information and Google Drive document
-#' information and have to be provided. Option \code{hide_code} allows to
-#' remove code chunks from the text document and option \code{update}
+#' information and have to be provided. Option `hide_code` allows to
+#' remove code chunks from the text document and option `update`
 #' indicates whether to update file in Google Drive.
 #'
 #' @param file character. The path (without file extension) of a local `.Rmd`
@@ -88,7 +88,7 @@ evaluate_file <- function(file,
 #'   are displayed instead.
 #' @param update logical value indicating whether to update or upload the
 #'   document.
-#' @param rich_text [experimental] logical value (default is \code{TRUE})
+#' @param rich_text [experimental] logical value (default is `TRUE`)
 #'   indicating whether to upload to Google Docs a rich document (i.e.,
 #'   important text that should not be changed is highlighted).
 #' @param rich_text_par [experimental] argument used to pass a list with custom
@@ -188,8 +188,8 @@ upload_document <- function(file, file_info,
 #'
 #' Internal function to upload (or update) a local file to Google Drive as a
 #' plain text document. Local file information and Google Drive document
-#' information and have to be provided. Option \code{hide_code} allows to
-#' remove code chunks from the text document and option \code{update}
+#' information and have to be provided. Option `hide_code` allows to
+#' remove code chunks from the text document and option `update`
 #' indicates whether to update file in Google Drive.
 #'
 #' @param path_output character. The path (without file extension) of a local
@@ -205,7 +205,7 @@ upload_document <- function(file, file_info,
 #' @param .response integer indicating automatic response in non interactive
 #'   environment on whether to convert html to pdf (1 = Yes, 2 = No).
 #' @param force logical value indicating whether to skip confirm check by user
-#'   (default is \code{FALSE}).
+#'   (default is `FALSE`).
 #'
 #' @return a dribble of the uploaded (or updated) output
 #' @noRd

--- a/R/utils_namer.R
+++ b/R/utils_namer.R
@@ -46,14 +46,14 @@ quote_label <-  function(x) {
 #' @param info_patterns a list with the regex pattern according to file
 #'   extension, returned by get_extension_patterns() function
 #'
-#' @return  a tibble with \itemize{
-#'   \item{language} of the chunk
-#'   \item{name} of the chunk
-#'   \item{options} of the chunk
-#'   \item{starts} the line number of the chunk header
-#'   \item{ends} the line number of the chunk end
-#'   \item{index} integer index to identify the chunk
-#' }
+#' @return  a tibble with
+#'  - **language** of the chunk
+#'  - **name** of the chunk
+#'  - **options** of the chunk
+#'  - **starts** the line number of the chunk header
+#'  - **ends** the line number of the chunk end
+#'  - **index** integer index to identify the chunk
+#' 
 #' Note that in case of "rnw" extension the language is always NA. NULL is
 #' returned if no chunk was available.
 #' @noRd
@@ -109,11 +109,11 @@ get_chunk_info <- function(lines, info_patterns){
 #' @param info_patterns a list with the regex pattern according to file
 #'   extension, returned by get_extension_patterns() function
 #'
-#' @return  a tibble with \itemize{
-#'   \item{language} of the chunk
-#'   \item{name} of the chunk
-#'   \item{options} of the chunk
-#' }
+#' @return  a tibble with
+#'  - **language** of the chunk
+#'  - **name** of the chunk
+#'  - **options** of the chunk
+#' 
 #' Note that in case of "rnw" extension the language is always NA
 #' @noRd
 #'
@@ -155,11 +155,11 @@ parse_chunk_header <- function(chunk_header, info_patterns){
 #' @param info_patterns a list with the regex pattern according to file
 #'   extension, returned by get_extension_patterns() function
 #'
-#' @return  a tibble with \itemize{
-#'   \item{language} of the chunk
-#'   \item{name} of the chunk
-#'   \item{options} of the chunk
-#' }
+#' @return  a tibble with
+#'  - **language** of the chunk
+#'  - **name** of the chunk
+#'  - **options** of the chunk
+#' 
 #' Note that in case of "rnw" extension the language is always NA
 #' @noRd
 #'
@@ -201,11 +201,11 @@ digest_chunk_header <- function(chunk_header_index,
 #' @param params a string indicating the content of a chunk header
 #' @param extension a indicating the extension of the file ("rmd" or "rnw")
 #'
-#' @return  a tibble with \itemize{
-#'   \item{language} of the chunk
-#'   \item{name} of the chunk
-#'   \item{options} of the chunk
-#' }
+#' @return  a tibble with
+#'  - **language** of the chunk
+#'  - **name** of the chunk
+#'  - **options** of the chunk
+#' 
 #' Note that in case of "rnw" extension the language is always NA
 #' @noRd
 #'

--- a/R/utils_rich_text.R
+++ b/R/utils_rich_text.R
@@ -154,10 +154,9 @@ get_patterns_highlight <- function(extension){
 #' @param text a single string with the parsed document that has been uploaded
 #'   to Google Drive.
 #'
-#' @return a data frame indicating for each match:\itemize{ 
-#'   \item{start_index} starting position index  
-#'   \item{end_index} ending position index  
-#'   }
+#' @return a data frame indicating for each match: 
+#'   - **start_index** starting position index  
+#'   - **end_index** ending position index  
 #'
 #' @noRd
 #' @examples

--- a/man/download_file.Rd
+++ b/man/download_file.Rd
@@ -14,7 +14,7 @@ download_file(
 )
 }
 \arguments{
-\item{file}{character. The path of a local `.Rmd`, Quarto, or `.Rnw` file.}
+\item{file}{character. The path of a local \code{.Rmd}, Quarto, or \code{.Rnw} file.}
 
 \item{gfile}{character. The name of a Google Drive file (defaults to local
 file name).}
@@ -28,20 +28,20 @@ level, although it is not recommended.}
 \item{shared_drive}{character. The name of a Google Drive shared drive
 (optional).}
 
-\item{rm_gcomments}{[experimental] logical value indicating whether or not to
+\item{rm_gcomments}{\link{experimental} logical value indicating whether or not to
 remove Google comments.}
 
 \item{force}{logical value indicating whether to skip confirm check by user
 (default is \code{FALSE}).}
 }
 \value{
-`TRUE` if file from Google Drive was saved, `FALSE` otherwise.
+\code{TRUE} if file from Google Drive was saved, \code{FALSE} otherwise.
 }
 \description{
 Download edited version of a file from Google Drive updating the local
 version with the new changes.\cr\cr
 \emph{Use with caution as local version of the file will be
-overwritten!}\cr\cr 
+overwritten!}\cr\cr
 To know more about \code{trackdown} workflow and features see
-\code{\link{trackdown-package}} help page.
+\code{\link[=trackdown-package]{trackdown-package()}} help page.
 }

--- a/man/download_file.Rd
+++ b/man/download_file.Rd
@@ -28,7 +28,7 @@ level, although it is not recommended.}
 \item{shared_drive}{character. The name of a Google Drive shared drive
 (optional).}
 
-\item{rm_gcomments}{\link{experimental} logical value indicating whether or not to
+\item{rm_gcomments}{(experimental) logical value indicating whether or not to
 remove Google comments.}
 
 \item{force}{logical value indicating whether to skip confirm check by user

--- a/man/render_file.Rd
+++ b/man/render_file.Rd
@@ -31,7 +31,7 @@ level, although it is not recommended.}
 \item{force}{logical value indicating whether to skip confirm check by user
 (default is \code{FALSE}).}
 
-\item{rm_gcomments}{\link{experimental} logical value indicating whether or not to
+\item{rm_gcomments}{(experimental) logical value indicating whether or not to
 remove Google comments.}
 }
 \value{

--- a/man/render_file.Rd
+++ b/man/render_file.Rd
@@ -14,7 +14,7 @@ render_file(
 )
 }
 \arguments{
-\item{file}{character. The path of a local `.Rmd`, Quarto, or `.Rnw` file.}
+\item{file}{character. The path of a local \code{.Rmd}, Quarto, or \code{.Rnw} file.}
 
 \item{gfile}{character. The name of a Google Drive file (defaults to local
 file name).}
@@ -31,15 +31,15 @@ level, although it is not recommended.}
 \item{force}{logical value indicating whether to skip confirm check by user
 (default is \code{FALSE}).}
 
-\item{rm_gcomments}{[experimental] logical value indicating whether or not to
+\item{rm_gcomments}{\link{experimental} logical value indicating whether or not to
 remove Google comments.}
 }
 \value{
-`TRUE` if file from Google Drive was saved and rendered, `FALSE`
-  otherwise.
+\code{TRUE} if file from Google Drive was saved and rendered, \code{FALSE}
+otherwise.
 }
 \description{
 Render file from Google Drive if there have been edits\cr\cr
 To know more about \code{trackdown} workflow and features see
-\code{\link{trackdown-package}} help page.
+\code{\link[=trackdown-package]{trackdown-package()}} help page.
 }

--- a/man/trackdown-package.Rd
+++ b/man/trackdown-package.Rd
@@ -38,7 +38,7 @@ continues until the desired results are obtained. The workflow can be
 summarized as:
 
 \emph{Collaborative \strong{code} writing using \strong{Git} & collaborative writing
-of \strong{narrative text} using \strong{Google Docs} }
+of \strong{narrative text} using \strong{Google Docs}}
 }
 
 \section{Functions}{

--- a/man/trackdown-package.Rd
+++ b/man/trackdown-package.Rd
@@ -16,45 +16,45 @@ document can be downloaded and rendered locally.
 }
 \section{The \code{trackdown} Workflow}{
 
- During the collaborative writing/editing of an \code{.Rmd} (or \code{.Rnw})
- document, it is important to employ different workflows for computer code
- and narrative text:
+During the collaborative writing/editing of an \code{.Rmd} (or \code{.Rnw})
+document, it is important to employ different workflows for computer code
+and narrative text:
 
- \itemize{ 
-  \item{\strong{Code} - Collaborative code writing is done most efficiently
-  by following a traditional \strong{Git}-based workflow using an online
-  repository (e.g., GitHub or GitLab).}
-  \item{\strong{Narrative Text} - Collaborative writing of narrative text is
-  done most efficiently using \strong{Google Docs} which provides a familiar
-  and simple online interface that allows multiple users to simultaneously
-  write/edit the same document.}
-  }
+\itemize{
+\item{\strong{Code} - Collaborative code writing is done most efficiently
+by following a traditional \strong{Git}-based workflow using an online
+repository (e.g., GitHub or GitLab).}
+\item{\strong{Narrative Text} - Collaborative writing of narrative text is
+done most efficiently using \strong{Google Docs} which provides a familiar
+and simple online interface that allows multiple users to simultaneously
+write/edit the same document.}
+}
 
- Thus, the workflow’s main idea is simple: Upload the \code{.Rmd} (or \code{.Rnw})
- document to Google Drive to collaboratively write/edit the narrative text in
- Google Docs; download the document locally to continue working on the code
- while harnessing the power of Git for version control and collaboration.
- This iterative process of uploading to and downloading from Google Drive
- continues until the desired results are obtained. The workflow can be
- summarized as:
+Thus, the workflow’s main idea is simple: Upload the \code{.Rmd} (or \code{.Rnw})
+document to Google Drive to collaboratively write/edit the narrative text in
+Google Docs; download the document locally to continue working on the code
+while harnessing the power of Git for version control and collaboration.
+This iterative process of uploading to and downloading from Google Drive
+continues until the desired results are obtained. The workflow can be
+summarized as:
 
- \emph{Collaborative \strong{code} writing using \strong{Git} & collaborative writing
- of \strong{narrative text} using \strong{Google Docs} }
+\emph{Collaborative \strong{code} writing using \strong{Git} & collaborative writing
+of \strong{narrative text} using \strong{Google Docs} }
 }
 
 \section{Functions}{
 
- \code{trackdown} offers different functions to manage the workflow:
- \itemize{
-  \item{\code{\link{upload_file}} uploads a file for the first time to Google
-  Drive.}
-  \item{\code{\link{update_file}} updates the content of an existing file in
-  Google Drive with the contents of a local file.}
-  \item{\code{\link{download_file}} downloads the edited version of a file
-  from Google Drive and updates the local version.}
-  \item{\code{\link{render_file}} downloads a file from Google Drive and
-  renders it locally.}
- }
+\code{trackdown} offers different functions to manage the workflow:
+\itemize{
+\item{\code{\link[=upload_file]{upload_file()}} uploads a file for the first time to Google
+Drive.}
+\item{\code{\link[=update_file]{update_file()}} updates the content of an existing file in
+Google Drive with the contents of a local file.}
+\item{\code{\link[=download_file]{download_file()}} downloads the edited version of a file
+from Google Drive and updates the local version.}
+\item{\code{\link[=render_file]{render_file()}} downloads a file from Google Drive and
+renders it locally.}
+}
 }
 
 \section{Special Features}{
@@ -63,58 +63,58 @@ document can be downloaded and rendered locally.
 writing and editing of documents in Google Docs. In particular, it is
 possible to:
 \itemize{
-  \item{\strong{Hide Code:} Code in the header of the document (YAML header
-  or LaTeX preamble) and code chunks are removed from the document when
-  uploading to Google Drive and are automatically restored during download.
-  This prevents collaborators from inadvertently making changes to the code
-  which might corrupt the file and allows them to focus on the narrative
-  text.}
-  \item{\strong{Upload Output:} The actual output document (i.e., the
-  rendered file) can be uploaded to Google Drive in conjunction with the
-  \code{.Rmd} (or \code{.Rnw}) document. This helps collaborators to evaluate
-  the overall layout including figures and tables and allows them to add
-  comments to suggest and discuss changes.}
-  \item{\strong{Use Google Drive shared drives:} The documents can be
-  uploaded on your personal Google Drive or on a shared drive to facilitate
-  collaboration.}
- }
+\item{\strong{Hide Code:} Code in the header of the document (YAML header
+or LaTeX preamble) and code chunks are removed from the document when
+uploading to Google Drive and are automatically restored during download.
+This prevents collaborators from inadvertently making changes to the code
+which might corrupt the file and allows them to focus on the narrative
+text.}
+\item{\strong{Upload Output:} The actual output document (i.e., the
+rendered file) can be uploaded to Google Drive in conjunction with the
+\code{.Rmd} (or \code{.Rnw}) document. This helps collaborators to evaluate
+the overall layout including figures and tables and allows them to add
+comments to suggest and discuss changes.}
+\item{\strong{Use Google Drive shared drives:} The documents can be
+uploaded on your personal Google Drive or on a shared drive to facilitate
+collaboration.}
+}
 }
 
 \section{Advantages of Google Docs}{
 
- Google Docs offers users a familiar, intuitive, and free web-based interface
- that allows multiple users to simultaneously write/edit the same document.
- In Google Docs it is possible to:
- \itemize{
-  \item{track changes (incl. accepting/rejecting suggestions)}
-  \item{add comments to suggest and discuss changes}
-  \item{check spelling and grammar errors (potentially integrating
-  third-party services like Grammarly)}
- }
- Moreover, Google Docs allows anyone to contribute to the writing/editing of
- the document. No programming experience is required, users can just focus on
- writing/editing the narrative text.
- 
- Note that not all collaborators have to have a Google account (although this
- is recommended to utilize all Google Docs features). Only the person who
- manages the \code{trackdown} workflow needs to have a Google account to
- upload files to Google Drive. Other collaborators can be invited to
- contribute to the document using a shared link.
+Google Docs offers users a familiar, intuitive, and free web-based interface
+that allows multiple users to simultaneously write/edit the same document.
+In Google Docs it is possible to:
+\itemize{
+\item{track changes (incl. accepting/rejecting suggestions)}
+\item{add comments to suggest and discuss changes}
+\item{check spelling and grammar errors (potentially integrating
+third-party services like Grammarly)}
+}
+Moreover, Google Docs allows anyone to contribute to the writing/editing of
+the document. No programming experience is required, users can just focus on
+writing/editing the narrative text.
+
+Note that not all collaborators have to have a Google account (although this
+is recommended to utilize all Google Docs features). Only the person who
+manages the \code{trackdown} workflow needs to have a Google account to
+upload files to Google Drive. Other collaborators can be invited to
+contribute to the document using a shared link.
 }
 
 \section{Documentation and Vignettes}{
 
- All the documentation is available at \url{https://claudiozandonella.github.io/trackdown/}.
- 
- To know more about the \code{trackdown}, please reference:
- \itemize{
-  \item{\code{vignette("trackdown-features")} for a detailed description of
-  the function arguments and features.}
-  \item{\code{vignette("trackdown-workflow")} for a workflow example and
-  discussion of how to collaborate on narrative text and code.}
-  \item{\code{vignette("trackdown-tech-notes")} for details regarding
-  technical details like authentication and file management.}
- }
+All the documentation is available at \url{https://claudiozandonella.github.io/trackdown/}.
+
+To know more about the \code{trackdown}, please reference:
+\itemize{
+\item{\code{vignette("trackdown-features")} for a detailed description of
+the function arguments and features.}
+\item{\code{vignette("trackdown-workflow")} for a workflow example and
+discussion of how to collaborate on narrative text and code.}
+\item{\code{vignette("trackdown-tech-notes")} for details regarding
+technical details like authentication and file management.}
+}
 }
 
 \keyword{internal}

--- a/man/trackdown-package.Rd
+++ b/man/trackdown-package.Rd
@@ -19,15 +19,14 @@ document can be downloaded and rendered locally.
 During the collaborative writing/editing of an \code{.Rmd} (or \code{.Rnw})
 document, it is important to employ different workflows for computer code
 and narrative text:
-
 \itemize{
-\item{\strong{Code} - Collaborative code writing is done most efficiently
+\item \strong{Code} - Collaborative code writing is done most efficiently
 by following a traditional \strong{Git}-based workflow using an online
-repository (e.g., GitHub or GitLab).}
-\item{\strong{Narrative Text} - Collaborative writing of narrative text is
+repository (e.g., GitHub or GitLab).
+\item \strong{Narrative Text} - Collaborative writing of narrative text is
 done most efficiently using \strong{Google Docs} which provides a familiar
 and simple online interface that allows multiple users to simultaneously
-write/edit the same document.}
+write/edit the same document.
 }
 
 Thus, the workflow’s main idea is simple: Upload the \code{.Rmd} (or \code{.Rnw})
@@ -46,14 +45,14 @@ of \strong{narrative text} using \strong{Google Docs} }
 
 \code{trackdown} offers different functions to manage the workflow:
 \itemize{
-\item{\code{\link[=upload_file]{upload_file()}} uploads a file for the first time to Google
-Drive.}
-\item{\code{\link[=update_file]{update_file()}} updates the content of an existing file in
-Google Drive with the contents of a local file.}
-\item{\code{\link[=download_file]{download_file()}} downloads the edited version of a file
-from Google Drive and updates the local version.}
-\item{\code{\link[=render_file]{render_file()}} downloads a file from Google Drive and
-renders it locally.}
+\item \code{\link[=upload_file]{upload_file()}} uploads a file for the first time to Google
+Drive.
+\item \code{\link[=update_file]{update_file()}} updates the content of an existing file in
+Google Drive with the contents of a local file.
+\item downloads the edited version of a file
+from Google Drive and updates the local version.
+\item \code{\link[=render_file]{render_file()}} downloads a file from Google Drive and
+renders it locally.
 }
 }
 
@@ -63,20 +62,20 @@ renders it locally.}
 writing and editing of documents in Google Docs. In particular, it is
 possible to:
 \itemize{
-\item{\strong{Hide Code:} Code in the header of the document (YAML header
+\item \strong{Hide Code:} Code in the header of the document (YAML header
 or LaTeX preamble) and code chunks are removed from the document when
 uploading to Google Drive and are automatically restored during download.
 This prevents collaborators from inadvertently making changes to the code
 which might corrupt the file and allows them to focus on the narrative
-text.}
-\item{\strong{Upload Output:} The actual output document (i.e., the
+text.
+\item \strong{Upload Output:} The actual output document (i.e., the
 rendered file) can be uploaded to Google Drive in conjunction with the
 \code{.Rmd} (or \code{.Rnw}) document. This helps collaborators to evaluate
 the overall layout including figures and tables and allows them to add
-comments to suggest and discuss changes.}
-\item{\strong{Use Google Drive shared drives:} The documents can be
+comments to suggest and discuss changes.
+\item \strong{Use Google Drive shared drives:} The documents can be
 uploaded on your personal Google Drive or on a shared drive to facilitate
-collaboration.}
+collaboration.
 }
 }
 
@@ -86,11 +85,12 @@ Google Docs offers users a familiar, intuitive, and free web-based interface
 that allows multiple users to simultaneously write/edit the same document.
 In Google Docs it is possible to:
 \itemize{
-\item{track changes (incl. accepting/rejecting suggestions)}
-\item{add comments to suggest and discuss changes}
-\item{check spelling and grammar errors (potentially integrating
-third-party services like Grammarly)}
+\item track changes (incl. accepting/rejecting suggestions)
+\item add comments to suggest and discuss changes
+\item check spelling and grammar errors (potentially integrating
+third-party services like Grammarly)
 }
+
 Moreover, Google Docs allows anyone to contribute to the writing/editing of
 the document. No programming experience is required, users can just focus on
 writing/editing the narrative text.
@@ -108,12 +108,12 @@ All the documentation is available at \url{https://claudiozandonella.github.io/t
 
 To know more about the \code{trackdown}, please reference:
 \itemize{
-\item{\code{vignette("trackdown-features")} for a detailed description of
-the function arguments and features.}
-\item{\code{vignette("trackdown-workflow")} for a workflow example and
-discussion of how to collaborate on narrative text and code.}
-\item{\code{vignette("trackdown-tech-notes")} for details regarding
-technical details like authentication and file management.}
+\item \code{vignette("trackdown-features")} for a detailed description of
+the function arguments and features.
+\item \code{vignette("trackdown-workflow")} for a workflow example and
+discussion of how to collaborate on narrative text and code.
+\item \code{vignette("trackdown-tech-notes")} for details regarding
+technical details like authentication and file management.
 }
 }
 

--- a/man/trackdown_auth.Rd
+++ b/man/trackdown_auth.Rd
@@ -55,7 +55,7 @@ httr's class \code{request}, i.e. a token that has been prepared with
 }
 \description{
 Authorize trackdown to view and manage your trackdown files. This function is a
-wrapper around [gargle::token_fetch()].
+wrapper around \code{\link[gargle:token_fetch]{gargle::token_fetch()}}.
 
 By default, you are directed to a web browser, asked to sign in to your
 Google account, and to grant trackdown permission to operate on your
@@ -68,34 +68,36 @@ tokens are less likely to be synced to the cloud by accident.
 If you are interacting with R within a browser (applies to RStudio Server,
 RStudio Workbench, and RStudio Cloud), you need a variant of this flow,
 known as out-of-band auth ("oob"). If this does not happen
-automatically, you can request it yourself with `use_oob = TRUE` or,
+automatically, you can request it yourself with \code{use_oob = TRUE} or,
 more persistently, by setting an option via
-`options(gargle_oob_default = TRUE)`.
+\code{options(gargle_oob_default = TRUE)}.
 }
 \details{
-Most users, most of the time, do not need to call `trackdown_auth()`
+Most users, most of the time, do not need to call \code{trackdown_auth()}
 explicitly -- it is triggered by the first action that requires
 authorization. Even when called, the default arguments often suffice.
 However, when necessary, this function allows the user to explicitly:
-  * Declare which Google identity to use, via an email address. If there
-    are multiple cached tokens, this can clarify which one to use. It can
-    also force trackdown to switch from one identity to another. If
-    there's no cached token for the email, this triggers a return to the
-    browser to choose the identity and give consent. You can specify just
-    the domain by using a glob pattern. This means that a script
-    containing `email = "*@example.com"` can be run without further
-    tweaks on the machine of either `alice@example.com` or
-    `bob@example.com`.
-  * Use a service account token or workload identity federation.
-  * Bring their own [Token2.0][httr::Token-class].
-  * Specify non-default behavior re: token caching and out-of-bound
-    authentication.
-  * Customize scopes.
+\itemize{
+\item Declare which Google identity to use, via an email address. If there
+are multiple cached tokens, this can clarify which one to use. It can
+also force trackdown to switch from one identity to another. If
+there's no cached token for the email, this triggers a return to the
+browser to choose the identity and give consent. You can specify just
+the domain by using a glob pattern. This means that a script
+containing \code{email = "*@example.com"} can be run without further
+tweaks on the machine of either \code{alice@example.com} or
+\code{bob@example.com}.
+\item Use a service account token or workload identity federation.
+\item Bring their own \link[httr:Token-class]{Token2.0}.
+\item Specify non-default behavior re: token caching and out-of-bound
+authentication.
+\item Customize scopes.
+}
 
 For details on the many ways to find a token, see
-[gargle::token_fetch()]. For deeper control over auth, use
-[trackdown_auth_configure()] to bring your own OAuth app or API key.
-Read more about gargle options, see [gargle::gargle_options].
+\code{\link[gargle:token_fetch]{gargle::token_fetch()}}. For deeper control over auth, use
+\code{\link[=trackdown_auth_configure]{trackdown_auth_configure()}} to bring your own OAuth app or API key.
+Read more about gargle options, see \link[gargle:gargle_options]{gargle::gargle_options}.
 }
 \examples{
 \dontrun{

--- a/man/trackdown_auth_configure.Rd
+++ b/man/trackdown_auth_configure.Rd
@@ -10,29 +10,33 @@ trackdown_auth_configure(app, path)
 trackdown_oauth_app()
 }
 \arguments{
-\item{app}{OAuth app, in the sense of [httr::oauth_app()].}
+\item{app}{OAuth app, in the sense of \code{\link[httr:oauth_app]{httr::oauth_app()}}.}
 
 \item{path}{JSON downloaded from Google Cloud Platform Console, containing a
 client id (aka key) and secret, in one of the forms supported for the \code{txt}
 argument of \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}} (typically, a file path or JSON string).}
 }
 \value{
-* `trackdown_auth_configure()`: An object of R6 class
-    [gargle::AuthState], invisibly.
-  * `trackdown_oauth_app()`: the current user-configured
-    [httr::oauth_app()].
+\itemize{
+\item \code{trackdown_auth_configure()}: An object of R6 class
+\link[gargle:AuthState-class]{gargle::AuthState}, invisibly.
+\item \code{trackdown_oauth_app()}: the current user-configured
+\code{\link[httr:oauth_app]{httr::oauth_app()}}.
+}
 }
 \description{
 These functions give more control over and visibility into the auth
-configuration than [trackdown_auth()] does. `trackdown_auth_configure()`
+configuration than \code{\link[=trackdown_auth]{trackdown_auth()}} does. \code{trackdown_auth_configure()}
 lets the user specify their own:
-  * OAuth app, which is used when obtaining a user token.
+\itemize{
+\item OAuth app, which is used when obtaining a user token.
 See the vignette
-[How to get your own API credentials](https://gargle.r-lib.org/articles/get-api-credentials.html)
+\href{https://gargle.r-lib.org/articles/get-api-credentials.html}{How to get your own API credentials}
 for more.
 If the user does not configure these settings, internal defaults
 are used.
-`trackdown_oauth_app()` retrieves the currently configured OAuth app.
+\code{trackdown_oauth_app()} retrieves the currently configured OAuth app.
+}
 }
 \examples{
 # see the current user-configured OAuth app (probaby `NULL`)

--- a/man/trackdown_deauth.Rd
+++ b/man/trackdown_deauth.Rd
@@ -9,10 +9,10 @@ trackdown_deauth()
 \description{
 Clears any currently stored token. The next time trackdown needs a token, the
 token acquisition process starts over, with a fresh call to
-[trackdown_auth()] and, therefore, internally, a call to
-[gargle::token_fetch()]. Unlike some other packages that use gargle,
+\code{\link[=trackdown_auth]{trackdown_auth()}} and, therefore, internally, a call to
+\code{\link[gargle:token_fetch]{gargle::token_fetch()}}. Unlike some other packages that use gargle,
 trackdown is not usable in a de-authorized state. Therefore, calling
-`trackdown_deauth()` only clears the token, i.e. it does NOT imply that
+\code{trackdown_deauth()} only clears the token, i.e. it does NOT imply that
 subsequent requests are made with an API key in lieu of a token.
 }
 \examples{

--- a/man/trackdown_token.Rd
+++ b/man/trackdown_token.Rd
@@ -7,17 +7,17 @@
 trackdown_token()
 }
 \value{
-A `request` object (an S3 class provided by [httr][httr::httr]).
+A \code{request} object (an S3 class provided by \link[httr:httr-package]{httr}).
 }
 \description{
 For internal use or for those programming around the trackdown API.
-Returns a token pre-processed with [httr::config()]. Most users
+Returns a token pre-processed with \code{\link[httr:config]{httr::config()}}. Most users
 do not need to handle tokens "by hand" or, even if they need some
-control, [trackdown_auth()] is what they need. If there is no current
-token, [trackdown_auth()] is called to either load from cache or
+control, \code{\link[=trackdown_auth]{trackdown_auth()}} is what they need. If there is no current
+token, \code{\link[=trackdown_auth]{trackdown_auth()}} is called to either load from cache or
 initiate OAuth2.0 flow.
-If auth has been deactivated via [trackdown_deauth()], `trackdown_token()`
-returns `NULL`.
+If auth has been deactivated via \code{\link[=trackdown_deauth]{trackdown_deauth()}}, \code{trackdown_token()}
+returns \code{NULL}.
 }
 \examples{
 \dontrun{

--- a/man/trackdown_user.Rd
+++ b/man/trackdown_user.Rd
@@ -7,7 +7,7 @@
 trackdown_user()
 }
 \value{
-An email address or, if no token has been loaded, `NULL`.
+An email address or, if no token has been loaded, \code{NULL}.
 }
 \description{
 Reveals the email address of the user associated with the current token.
@@ -20,6 +20,6 @@ trackdown_user()
 
 }
 \seealso{
-[gargle::token_userinfo()], [gargle::token_email()],
-[gargle::token_tokeninfo()]
+\code{\link[gargle:token-info]{gargle::token_userinfo()}}, \code{\link[gargle:token-info]{gargle::token_email()}},
+\code{\link[gargle:token-info]{gargle::token_tokeninfo()}}
 }

--- a/man/update_file.Rd
+++ b/man/update_file.Rd
@@ -17,7 +17,7 @@ update_file(
 )
 }
 \arguments{
-\item{file}{character. The path of a local `.Rmd`, Quarto, or `.Rnw` file.}
+\item{file}{character. The path of a local \code{.Rmd}, Quarto, or \code{.Rnw} file.}
 
 \item{gfile}{character. The name of a Google Drive file (defaults to local
 file name).}
@@ -32,7 +32,7 @@ level, although it is not recommended.}
 (optional).}
 
 \item{hide_code}{logical value indicating whether to remove code from the
-text document (chunks and header). Placeholders of type "[[chunk-<name>]]"
+text document (chunks and header). Placeholders of type "[]"
 are displayed instead.}
 
 \item{path_output}{default \code{NULL}, specify the path to the output to
@@ -40,12 +40,12 @@ upload together with the other file. PDF are directly uploaded, HTML can be
 first converted into PDF if package \code{pagedown} and Chrome are
 available.}
 
-\item{rich_text}{[experimental] logical value (default is \code{TRUE})
+\item{rich_text}{\link{experimental} logical value (default is \code{TRUE})
 indicating whether to upload to Google Docs a rich document (i.e.,
 important text that should not be changed is highlighted). See “Rich Text”
 in details section.}
 
-\item{rich_text_par}{[experimental] argument used to pass a list with custom
+\item{rich_text_par}{\link{experimental} argument used to pass a list with custom
 settings for rich_text. See “Rich Text” in details section.}
 
 \item{force}{logical value indicating whether to skip confirm check by user
@@ -62,12 +62,12 @@ present) the output (pdf or html) of the file specifying the
 package and Chrome are available, users can decide to upload a pdf version of
 the html file.\cr\cr
 \emph{Use with caution as tracked changes in the Google Drive file will be
-lost!}\cr\cr 
+lost!}\cr\cr
 To know more about \code{trackdown} workflow and features see
-\code{\link{trackdown-package}} help page.
+\code{\link[=trackdown-package]{trackdown-package()}} help page.
 }
 \details{
-\strong{Rich Text [experimental]}
+\strong{Rich Text \link{experimental}}
 
 The \code{rich_text} option (default is \code{TRUE}) allows to upload a rich
 document to Google Docs. Important text that should not be changed is

--- a/man/update_file.Rd
+++ b/man/update_file.Rd
@@ -32,7 +32,7 @@ level, although it is not recommended.}
 (optional).}
 
 \item{hide_code}{logical value indicating whether to remove code from the
-text document (chunks and header). Placeholders of type "[]"
+text document (chunks and header). Placeholders of type \code{"[[chunk-<name>]]"}
 are displayed instead.}
 
 \item{path_output}{default \code{NULL}, specify the path to the output to

--- a/man/update_file.Rd
+++ b/man/update_file.Rd
@@ -40,12 +40,12 @@ upload together with the other file. PDF are directly uploaded, HTML can be
 first converted into PDF if package \code{pagedown} and Chrome are
 available.}
 
-\item{rich_text}{\link{experimental} logical value (default is \code{TRUE})
+\item{rich_text}{(experimental) logical value (default is \code{TRUE})
 indicating whether to upload to Google Docs a rich document (i.e.,
 important text that should not be changed is highlighted). See “Rich Text”
 in details section.}
 
-\item{rich_text_par}{\link{experimental} argument used to pass a list with custom
+\item{rich_text_par}{(experimental) argument used to pass a list with custom
 settings for rich_text. See “Rich Text” in details section.}
 
 \item{force}{logical value indicating whether to skip confirm check by user
@@ -67,7 +67,7 @@ To know more about \code{trackdown} workflow and features see
 \code{\link[=trackdown-package]{trackdown-package()}} help page.
 }
 \details{
-\strong{Rich Text \link{experimental}}
+\strong{Rich Text (experimental)}
 
 The \code{rich_text} option (default is \code{TRUE}) allows to upload a rich
 document to Google Docs. Important text that should not be changed is

--- a/man/upload_file.Rd
+++ b/man/upload_file.Rd
@@ -13,11 +13,12 @@ upload_file(
   path_output = NULL,
   rich_text = TRUE,
   rich_text_par = NULL,
-  force = FALSE
+  force = FALSE,
+  open = rlang::is_interactive()
 )
 }
 \arguments{
-\item{file}{character. The path of a local `.Rmd`, Quarto, or `.Rnw` file.}
+\item{file}{character. The path of a local \code{.Rmd}, Quarto, or \code{.Rnw} file.}
 
 \item{gfile}{character. The name of a Google Drive file (defaults to local
 file name).}
@@ -32,7 +33,7 @@ level, although it is not recommended.}
 (optional).}
 
 \item{hide_code}{logical value indicating whether to remove code from the
-text document (chunks and header). Placeholders of type "[[chunk-<name>]]"
+text document (chunks and header). Placeholders of type "[]"
 are displayed instead.}
 
 \item{path_output}{default \code{NULL}, specify the path to the output to
@@ -40,16 +41,19 @@ upload together with the other file. PDF are directly uploaded, HTML can be
 first converted into PDF if package \code{pagedown} and Chrome are
 available.}
 
-\item{rich_text}{[experimental] logical value (default is \code{TRUE})
+\item{rich_text}{\link{experimental} logical value (default is \code{TRUE})
 indicating whether to upload to Google Docs a rich document (i.e.,
 important text that should not be changed is highlighted). See “Rich Text”
 in details section.}
 
-\item{rich_text_par}{[experimental] argument used to pass a list with custom
+\item{rich_text_par}{\link{experimental} argument used to pass a list with custom
 settings for rich_text. See “Rich Text” in details section.}
 
 \item{force}{logical value indicating whether to skip confirm check by user
 (default is \code{FALSE}).}
+
+\item{open}{logical value indicating whether to open the created file in
+a browser (default is \code{TRUE} in interactive sessions).}
 }
 \value{
 a dribble of the uploaded file (and output if specified).
@@ -59,15 +63,15 @@ Uploads a local file to Google Drive as a plain text document. Will only
 upload the file if it doesn't already exist in the chosen location. By
 default files are uploaded in the folder "trackdown", if is not available on
 Google Drive, permission to create it is required to the user. To update an
-already existing file see \code{\link{update_file}}. It is also possible to
+already existing file see \code{\link[=update_file]{update_file()}}. It is also possible to
 upload the output (pdf or html) of the file specifying the \code{path_output}
 argument. In case of html files, if \code{pagedown} package and Chrome are
 available, users can decide to upload a pdf version of the html file.\cr\cr
 To know more about \code{trackdown} workflow and features see
-\code{\link{trackdown-package}} help page.
+\code{\link[=trackdown-package]{trackdown-package()}} help page.
 }
 \details{
-\strong{Rich Text [experimental]}
+\strong{Rich Text \link{experimental}}
 
 The \code{rich_text} option (default is \code{TRUE}) allows to upload a rich
 document to Google Docs. Important text that should not be changed is

--- a/man/upload_file.Rd
+++ b/man/upload_file.Rd
@@ -13,8 +13,7 @@ upload_file(
   path_output = NULL,
   rich_text = TRUE,
   rich_text_par = NULL,
-  force = FALSE,
-  open = rlang::is_interactive()
+  force = FALSE
 )
 }
 \arguments{
@@ -51,9 +50,6 @@ settings for rich_text. See “Rich Text” in details section.}
 
 \item{force}{logical value indicating whether to skip confirm check by user
 (default is \code{FALSE}).}
-
-\item{open}{logical value indicating whether to open the created file in
-a browser (default is \code{TRUE} in interactive sessions).}
 }
 \value{
 a dribble of the uploaded file (and output if specified).

--- a/man/upload_file.Rd
+++ b/man/upload_file.Rd
@@ -32,7 +32,7 @@ level, although it is not recommended.}
 (optional).}
 
 \item{hide_code}{logical value indicating whether to remove code from the
-text document (chunks and header). Placeholders of type "[]"
+text document (chunks and header). Placeholders of type \code{"[[chunk-<name>]]"}
 are displayed instead.}
 
 \item{path_output}{default \code{NULL}, specify the path to the output to

--- a/man/upload_file.Rd
+++ b/man/upload_file.Rd
@@ -40,12 +40,12 @@ upload together with the other file. PDF are directly uploaded, HTML can be
 first converted into PDF if package \code{pagedown} and Chrome are
 available.}
 
-\item{rich_text}{\link{experimental} logical value (default is \code{TRUE})
+\item{rich_text}{(experimental) logical value (default is \code{TRUE})
 indicating whether to upload to Google Docs a rich document (i.e.,
 important text that should not be changed is highlighted). See “Rich Text”
 in details section.}
 
-\item{rich_text_par}{\link{experimental} argument used to pass a list with custom
+\item{rich_text_par}{(experimental) argument used to pass a list with custom
 settings for rich_text. See “Rich Text” in details section.}
 
 \item{force}{logical value indicating whether to skip confirm check by user
@@ -67,7 +67,7 @@ To know more about \code{trackdown} workflow and features see
 \code{\link[=trackdown-package]{trackdown-package()}} help page.
 }
 \details{
-\strong{Rich Text \link{experimental}}
+\strong{Rich Text (experimental)}
 
 The \code{rich_text} option (default is \code{TRUE}) allows to upload a rich
 document to Google Docs. Important text that should not be changed is


### PR DESCRIPTION
Fix #51

I used `usethis::use_roxygen_md()` and `roxygen2md::roxygen2md()`.

Relevant link https://roxygen2.r-lib.org/articles/rd-formatting.html